### PR TITLE
Added prompt to reinstall winget when it is already present

### DIFF
--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -47,6 +47,7 @@
 [Version 4.0.3] - Updated UI.Xaml package as per winget-cli issue #4208.
 [Version 4.0.4] - Fixed detection for Windows multi-session.
 [Version 4.0.5] - Improved error handling when registering winget.
+[Version 4.0.6] - Added prompt to reinstall winget when it is already present.
 
 #>
 
@@ -701,9 +702,21 @@ if ($osVersion.Type -eq "Server" -and $osVersion.NumericVersion -lt 2022) {
 # Check if winget is already installed
 if (Get-WingetStatus) {
     if ($Force -eq $false) {
-        Write-Warning "winget is already installed, exiting..."
-        Write-Warning "If you want to reinstall winget, run the script with the -Force parameter."
-        ExitWithDelay 0 5
+        do {
+            $userChoice = Read-Host "`nwinget is already installed. Do you want to reinstall it? (y/n)"
+            $userChoice = $userChoice.ToLower()
+            if ($userChoice -ne 'y' -and $userChoice -ne 'n') {
+                Write-Host "Invalid input. Please enter 'y' for Yes or 'n' for No."
+            }
+        } while ($userChoice -ne 'y' -and $userChoice -ne 'n')
+
+        if ($userChoice -eq 'y') {
+            Write-Host "Reinstalling winget..."
+            $command = "cd '$pwd'; $($MyInvocation.Line) -Force"
+        } else {
+            Write-Host "`nExiting without reinstalling winget.`n"
+            ExitWithDelay 0 5
+        }
     }
 }
 

--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 4.0.5
+.VERSION 4.0.6
 
 .GUID 3b581edb-5d90-4fa1-ba15-4f2377275463
 
@@ -77,7 +77,7 @@ This script is designed to be straightforward and easy to use, removing the hass
 .PARAMETER Help
     Displays the full help information for the script.
 .NOTES
-	Version      : 4.0.5
+	Version      : 4.0.6
 	Created by   : asheroto
 .LINK
 	Project Site: https://github.com/asheroto/winget-install
@@ -94,7 +94,7 @@ param (
 )
 
 # Script information
-$CurrentVersion = '4.0.5'
+$CurrentVersion = '4.0.6'
 $RepoOwner = 'asheroto'
 $RepoName = 'winget-install'
 $PowerShellGalleryName = 'winget-install'


### PR DESCRIPTION
I've updated the if statement to check if winget is already installed. Users can still initiate the script with the "-Force" argument, or choose to reinstall winget directly without relaunching the script. Additionally, I've incorporated a do-while loop and converted the user input to lowercase to ensure that the input is always correct.

![image](https://github.com/asheroto/winget-install/assets/113114289/17037cee-704f-4027-9daf-e595824de9b1)
![image](https://github.com/asheroto/winget-install/assets/113114289/669d70d2-ce58-42fb-833c-fe95fc8fdac1)
