### PR TITLE
Set path correctly in Windows Server 2019

### DIFF
--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -1164,7 +1164,7 @@ try {
             Set-PathPermissions -FolderPath $WinGetFolderPath
 
             # Add Environment Path
-            Add-ToEnvironmentPath -PathToAdd $WinGetFolderPath
+            Add-ToEnvironmentPath -PathToAdd $WinGetFolderPath -Scope 'System'
         } else {
             Write-Warning "winget folder path not found. You may need to manually add winget's folder path to your system PATH environment variable."
         }


### PR DESCRIPTION
The function-call to `Add-ToEnvironmentPath` is missing a parameter