### PR TITLE
Enable SYSTEM context functionality for Installation Script

### DIFF
--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -464,7 +464,7 @@ function Get-WingetStatus {
 
     # Check if winget is installed
     if ($RunAsSystem) {
-        $winget = Find-WinGet
+        $winget = & (Find-WinGet) -v
     } else {
         $winget = Get-Command -Name winget -ErrorAction SilentlyContinue
     }
@@ -1103,7 +1103,7 @@ try {
     # winget (regular method, Windows 10+)
     # ============================================================================ #
 
-    if ($osVersion.NumericVersion -ne 2019 -and $AlternateInstallMethod -eq $false) {
+    if ($osVersion.NumericVersion -ne 2019 -and $AlternateInstallMethod -eq $false -and $RunAsSystem -eq $false) {
 
         Write-Section "winget"
 
@@ -1134,9 +1134,7 @@ try {
 
         # Add to environment PATH to avoid issues when usernames or user profile paths change, or when using non-Latin characters (see #45)
         # Adding with literal %LOCALAPPDATA% to ensure it isn't resolved to the current user's LocalAppData as a fixed path
-        if (!$RunAsSystem) {
-            Add-ToEnvironmentPath -PathToAdd "%LOCALAPPDATA%\Microsoft\WindowsApps" -Scope 'User'
-        }
+        Add-ToEnvironmentPath -PathToAdd "%LOCALAPPDATA%\Microsoft\WindowsApps" -Scope 'User'
 
     }
 
@@ -1144,7 +1142,7 @@ try {
     #  Server 2019 only
     # ============================================================================ #
 
-    if (($osVersion.Type -eq "Server" -and ($osVersion.NumericVersion -eq 2019)) -or $AlternateInstallMethod) {
+    if (($osVersion.Type -eq "Server" -and ($osVersion.NumericVersion -eq 2019)) -or $AlternateInstallMethod -or $RunAsSystem) {
 
         # ============================================================================ #
         # Install prerequisites

--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -145,6 +145,7 @@ if ($PSBoundParameters.ContainsKey('Debug') -and $PSBoundParameters['Debug']) {
 # Check if running as SYSTEM
 $RunAsSystem = $false
 if ([System.Security.Principal.WindowsIdentity]::GetCurrent().Name -match "NT AUTHORITY\\SYSTEM") {
+    Write-Debug "Running as SYSTEM"
     $RunAsSystem = $true
 }
 
@@ -160,22 +161,14 @@ function Find-WinGet {
         $WinGetPath = $ResolveWinGetPath[-1].Path
     }
 
-    # Get the User-Context WinGet exe location.
-    $WinGetExePath = Get-Command -Name winget.exe -CommandType Application -ErrorAction SilentlyContinue
+    $WinGet = Join-Path $WinGetPath 'winget.exe'
 
-    # Select the correct WinGet exe
-    if (Test-Path -Path (Join-Path $WinGetPath 'winget.exe')) {
-        # Running in SYSTEM-Context.
-        $WinGet = Join-Path $WinGetPath 'winget.exe'
-    } elseif ($WinGetExePath) {
-        # Get User-Context if SYSTEM-Context not found.
-        $WinGet = $WinGetExePath.Path
+    # Test if WinGet Executable exists
+    if (Test-Path -Path $WinGet) {
+        return $WinGet
     } else {
         return $null
     }
-
-    # Return WinGet Location
-    return $WinGet
 }
 
 function Get-OSInfo {


### PR DESCRIPTION
These modifications would allow you to run this script under the SYSTEM contect, which would enable functionality with RMM systems and Microsoft Intune, as those softwares usually run all their scripts under the `NT AUTHORITY\SYSTEM` user.

The changes do the following:
- Add the `$RunAsSystem` variable that reflects weather the user is `SYSTEM` or not.
- Include the `Find-WinGet` function to get the location of `winget.exe` for the SYSTEM user.
- Modifies `Get-WingetStatus` to check for Winget using the `Find-WinGet` function if `$RunAsSystem` is true.
- Forces script to run the "Alt Install Method" if `$RunAsSystem` is true.

This feature is REALLY needed in this script. A lot of people would LOVE to use this if it had RMM support with the SYSTEM user.
