### PR TITLE
from Name to SID für SYSTEM-User dedection

### DIFF
--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -148,7 +148,7 @@ if ($PSBoundParameters.ContainsKey('Debug') -and $PSBoundParameters['Debug']) {
 
 # Check if running as SYSTEM
 $RunAsSystem = $false
-if ([System.Security.Principal.WindowsIdentity]::GetCurrent().Name -match "NT AUTHORITY\\SYSTEM") {
+if ([System.Security.Principal.WindowsIdentity]::GetCurrent().User -match "S-1-5-18") {
     Write-Debug "Running as SYSTEM"
     $RunAsSystem = $true
 }


### PR DESCRIPTION
Since not every OS language reports the same name (for example, the German version reports "NT-AUTORITÄT\SYSTEM"), I changed it to use the SID, which should always be the same.