### PR TITLE
Fix the type annotation on Apply-PathPermissionsFixAndAddPath OSVersi…

### DIFF
--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -1234,7 +1234,7 @@ function Install-LibIfRequired {
 function Apply-PathPermissionsFixAndAddPath {
     param(
         [Parameter(Mandatory)]
-        [string]$OSVersion
+        [PSCustomObject]$OSVersion
     )
 
     # ============================================================================ #


### PR DESCRIPTION
…on parameter

Coercing $OSVersion into a string prevents subsequent checks from evaluating correctly.